### PR TITLE
Added PrepSCTFindMarkers and cell cycle marker plots for cluster qc

### DIFF
--- a/R/general_configuration.R
+++ b/R/general_configuration.R
@@ -17,13 +17,17 @@ options(future.plan="multisession")
 # Use v5 assays in Seurat
 options(Seurat.object.assay.version="v5")
 
-# Python3 path needed for clustering, umap, other python packages
-conda_envs = reticulate::conda_list()
-if ("python" %in% conda_envs$name) {
-  reticulate::use_condaenv("python")
+# Conda environment or python path needed for clustering, umap, other python packages
+# Note: maybe we can move to this to a _environment.local file
+conda_env = NULL
+python_path = NULL
+if (!is.null(conda_env)) {
+    reticulate::use_condaenv(conda_env)
+} else if (!is.null(python_path)) {
+    Sys.setenv(RETICULATE_PYTHON=python_path)
 } else {
-  reticulate_python3_path = unname(Sys.which("python3"))
-  Sys.setenv(RETICULATE_PYTHON=reticulate_python3_path)
+    python_path = unname(Sys.which("python3"))
+    Sys.setenv(RETICULATE_PYTHON=python_path)
 }
 
 assertthat::assert_that(reticulate::py_available(initialize = TRUE) && !is.null(reticulate::py_config()), msg="Python3 not available")

--- a/_quarto-scrnaseq.yml
+++ b/_quarto-scrnaseq.yml
@@ -42,12 +42,12 @@ params:
   general:
 
     # General
-    project_id: "nobfx"
+    project_id: "project"
     species: "homo_sapiens"
     ensembl: 104
 
     # Technical
-    verbose: true
+    verbose: false
     on_disk_counts: false
     on_disk_use_tmp: false
     cores: 8
@@ -62,7 +62,7 @@ params:
     - "pERCC_RNA"
     - "pXIST_RNA"
     - "pChrY_RNA"
-    - "scrublet_doublet_scores"
+    - "doublet_scores"
     use_sketching: false
 
   modules:
@@ -84,7 +84,9 @@ params:
       barcode_qc_cor:
       - "nFeature_RNA nCount_RNA"
       - "nFeature_RNA pMito_RNA"
-      barcode_filter: null
+      barcode_filter: !expr list(
+          nFeature_RNA=c(200, NA), 
+          percent_mt=c(0, 50))
       feature_filter: !expr list(
         min_counts = 1,
         min_cells = 3)

--- a/modules/2_qc_filtering/rna/qc_filtering.qmd
+++ b/modules/2_qc_filtering/rna/qc_filtering.qmd
@@ -1135,8 +1135,8 @@ sc = CCScoring(sc, genes_s=unname(seurat_s_genes), genes_g2m=unname(seurat_g2m_g
 
 # Warn if there not enough genes for cell cycle scoring
 if (length(seurat_s_genes) < 20 | length(seurat_g2m_genes) < 20) {
-  CalloutBox(x="Cannot not find enough known S or G2M phase genes to be used cell cycle scoring. Phases and scores will be NA!", type="warning")
-  have_cell_cycle_scores = FALSE
+    CalloutBox(x="Cannot not find enough known S or G2M phase genes to be used cell cycle scoring. Phases and scores will be NA!", type="warning")
+    have_cell_cycle_scores = FALSE
 } else {
     have_cell_cycle_scores = TRUE
 }
@@ -1217,8 +1217,8 @@ Alternatively, the expression of MKI67 (a common G2M phase marker) and PCNA (a c
 #| label: qc_filtering_rna_cell_cycle_mki67_pcna
 #| results: asis
 
-# Get rownames for MKI67 (G2M phase) and PCNA (S phase)
-# Note: we use the human symbols that - in case of another species - get mapped to the orthologues
+# Get symbol for MKI67 (G2M phase) and PCNA (S phase) from the gene lists for cell cycle
+# Note: the names of the list values correspond to the human gene symbols and the values to the species-specific gene symbols
 idx = match("MKI67", names(seurat_g2m_genes))
 if (!is.na(idx)) {
   mki67 = seurat_g2m_genes[[idx[1]]]
@@ -1227,7 +1227,7 @@ if (!is.na(idx)) {
   CalloutBox(x="Could not find 'MKI67' or its orthologue in the data!", type="warning")
 }
 
-idx = match("PCNA", names(seurat_g2m_genes))
+idx = match("PCNA", names(seurat_s_genes))
 if (!is.na(idx)) {
   pcna = seurat_s_genes[[idx[1]]]
 } else {

--- a/modules/4_dimensionality_reduction/rna/dimensionality_reduction.qmd
+++ b/modules/4_dimensionality_reduction/rna/dimensionality_reduction.qmd
@@ -483,6 +483,22 @@ if (!grepl(pattern="_SCT", x=default_assay)) {
   if (length(layer_counts) == 1) SeuratObject::LayerData(sc, layer=layer_counts) = NULL
   if (length(layer_data) == 1) SeuratObject::LayerData(sc, layer=layer_data) = NULL
 }
+
+# If SCTransform was run:
+# - SCTransform analyses each dataset separately thereby creating models that are used to correct the dataset.
+# - In the SCT assay, counts and data are still only corrected within the datasets but not between the datasets.
+#   Counts and data are only valid if all datasets have the same sequencing depth.
+# - If not, PrepSCTFindMarkers needs to be run which does a joint normalization using a geometric mean (similar to DESeq2).
+# - https://github.com/dcgc-bfx/scrnaseq2/issues/37 and https://github.com/satijalab/seurat/issues/6675
+if (grepl(pattern="_SCT", x=default_assay)) {
+    sc = PrepSCTFindMarkers(sc, assay=default_assay, verbose=verbose)
+    
+    # If sketching was used, also apply to sketch
+    if (use_sketching) {
+        sketched_assay_name = paste(Seurat::DefaultAssay(sc), "sketch", sep=".")
+        sc = PrepSCTFindMarkers(sc, assay=sketched_assay_name, verbose=verbose)
+    }
+}
 ```
 
 ```{r}
@@ -499,7 +515,8 @@ reductions = dplyr::case_match(integration_methods,
                                    "RPCAIntegration" ~ "rpca",
                                    "HarmonyIntegration" ~ "harmony",
                                    "FastMNNIntegration" ~ "mnn",
-                                   "scVIIntegration" ~ "scvii")
+                                   "scVIIntegration" ~ "scvii",
+                               TRUE ~ "NA")
 
 plist = purrr::map(reductions, function(method) {
   title = SeuratObject::Misc(sc[[method]], slot="title")
@@ -559,6 +576,7 @@ cat(":::\n")
 #| label: dimensionality_reduction_rna_save_reduction
 #| results: asis
 
+# Default reduction
 default_reduct = DefaultReduct(sc)
 reduct = sc[[default_reduct]]@cell.embeddings %>% as.data.frame()
 

--- a/modules/4_dimensionality_reduction/rna/dimensionality_reduction.qmd
+++ b/modules/4_dimensionality_reduction/rna/dimensionality_reduction.qmd
@@ -361,7 +361,6 @@ The top PC captures the greatest variance across cells and each subsequent PC re
 dim_n_compute = param("dim_n_compute")
 dim_n = param("dim_n")
 
-
 # Plot the variance explained for the computed components
 p = Seurat::ElbowPlot(sc, reduction=DefaultReduct(sc), ndims=min(dim_n_compute, ncol(sc))) + 
   geom_vline(xintercept=dim_n + .5, col="firebrick", lty=2) + 

--- a/modules/6_clusterqc/clusterqc.qmd
+++ b/modules/6_clusterqc/clusterqc.qmd
@@ -16,7 +16,7 @@ params:
   default_assay: null
 
   # QC measures to look at 
-  qc_features:
+  barcode_qc:
   - "nCount_RNA"
   - "nFeature_RNA"
   - "pMito_RNA"
@@ -145,23 +145,23 @@ Do cells in individual clusters have particularly high counts, detected genes or
 #| results: asis
 
 # QC features to plot
-qc_features = param("barcode_qc")
-f = qc_features %in% colnames(sc[[]])
+barcode_qc = param("barcode_qc")
+f = barcode_qc %in% colnames(sc[[]])
 if (!all(f)) {
-  CalloutBox(x="Cannot find QC {qc_features[!f]*} in barcode metadata.", type="warning")
-  qc_features = qc_features[f]
+  CalloutBox(x="Cannot find QC {barcode_qc[!f]*} in barcode metadata.", type="warning")
+  barcode_qc = barcode_qc[f]
 }
 
 # Don't plot QC if there aren't any features to plot
-if (length(qc_features) > 0) {
+if (length(barcode_qc) > 0) {
     
   # If there are more than 25 cluster, plots need to be optimised so that they are not too crowded
   optimise_plots = levels(sc$seurat_clusters) %>% length() >= 25
 
   # Left: QC on UMAP
-  plist1 = Seurat::FeaturePlot(sc, features=qc_features, combine=FALSE, order=TRUE)
+  plist1 = Seurat::FeaturePlot(sc, features=barcode_qc, combine=FALSE, order=TRUE)
   for (i in seq(plist1)) {
-    q = qc_features[i]
+    q = barcode_qc[i]
     
     plist1[[i]] = plist1[[i]] + 
         AddPlotStyle(title=q, xlab="", ylab="") +
@@ -169,10 +169,10 @@ if (length(qc_features) > 0) {
         theme(legend.key.width = unit(0.01, "npc"), legend.position=ifelse(optimise_plots, "none", "right"))
     plist1[[i]] = Seurat::LabelClusters(plist1[[i]], id="ident", box=TRUE, fill="white", label.padding=unit(0.05, "lines"))
   }
-  names(plist1) = qc_features
+  names(plist1) = barcode_qc
   
   # Right: QC as violin plots
-  plist2 = lapply(qc_features, function(x) {
+  plist2 = lapply(barcode_qc, function(x) {
     p = ggplot(sc[[]] %>% dplyr::select(seurat_clusters, qc=x), 
                aes(x=seurat_clusters, y=qc, fill=seurat_clusters, group=seurat_clusters)) + 
       geom_violin(scale="width", linewidth=ifelse(optimise_plots, 0.1, 0.5)) + 
@@ -182,15 +182,15 @@ if (length(qc_features) > 0) {
       theme(axis.text.x=element_text(angle=45, hjust=1, vjust=1))
     return(p)
   })
-  names(plist2) = qc_features
+  names(plist2) = barcode_qc
   
   # Combine both plots with the patchwork library
-  plist = lapply(qc_features, function(x) {
+  plist = lapply(barcode_qc, function(x) {
     p = plist1[[x]] + plist2[[x]]
     return(p)
   })
-  captions = GeneratePlotCaptions(qc_features, assay_names=SeuratObject::Assays(sc), capitalize=TRUE)
-  names(plist) = names(captions) = qc_features
+  captions = GeneratePlotCaptions(barcode_qc, assay_names=SeuratObject::Assays(sc), capitalize=TRUE)
+  names(plist) = names(captions) = barcode_qc
   
   # Set up layout and automatically generate chunks
   chunk_template = "
@@ -207,7 +207,7 @@ plist[['{{type}}']]
   
   cat("::: panel-tabset\n")
   
-  for (x in qc_features) {
+  for (x in barcode_qc) {
     chunk_filled =  knitr::knit_expand(text=chunk_template, type=x, caption=captions[x])
     if(interactive()) {
       print(EvalKnitrChunk(chunk_filled))

--- a/modules/6_clusterqc/clusterqc.qmd
+++ b/modules/6_clusterqc/clusterqc.qmd
@@ -145,7 +145,7 @@ Do cells in individual clusters have particularly high counts, detected genes or
 #| results: asis
 
 # QC features to plot
-qc_features = param("qc_features")
+qc_features = param("barcode_qc")
 f = qc_features %in% colnames(sc[[]])
 if (!all(f)) {
   CalloutBox(x="Cannot find QC {qc_features[!f]*} in barcode metadata.", type="warning")
@@ -223,7 +223,9 @@ plist[['{{type}}']]
 
 ## Cell Cycle Effects {#sec-clusterqc-cc}
 
-How much do gene expression profiles in the dataset reflect the cell cycle phases the single cells were in? After initial normalisation, we determined the effects of cell cycle heterogeneity by calculating a score for each cell based on its expression of G2M and S phase markers. Scoring is based on the strategy described in @Tirosh_2016, and human gene symbols are translated to gene symbols of the species of interest using biomaRt. This section of the report visualizes the above calculated cell cycle scores. 
+How much do gene expression profiles in the dataset reflect the cell cycle phases the single cells were in? After initial normalisation, we determined the effects of cell cycle heterogeneity by calculating a score for each cell based on its expression of G2M and S phase markers. Scoring is based on the strategy described in @Tirosh_2016, and human gene symbols are translated to gene symbols of the species of interest using biomaRt. This section of the report visualizes the above calculated cell cycle scores.
+
+Alternatively, the expression of MKI67 (a common G2M phase marker) and PCNA (a common S phase marker), if available, can be used to get an impression of possible cell-cycle effects in the data.
 
 ```{r}
 #| label: clusterqc_cellcycle
@@ -234,6 +236,28 @@ have_cellcyle_scores = sc$Phase %>% is.na() %>% all() %>% not()
 
 if (!have_cellcyle_scores) CalloutBox(x="All cell cycle scores are zero and cell cycle information is not available. Most likely there were not enough S or G2M phase genes available for calculation.", type="warning")
 
+# Do we have MKI67 and PCNA?
+
+# Get symbol for MKI67 (G2M phase) and PCNA (S phase) from the gene lists for cell cycle
+# Note: the names of the list values correspond to the human gene symbols and the values to the species-specific gene symbols
+seurat_g2m_genes = ScLists(sc, lists_slot="gene_lists", list="CC_G2M_phase")
+idx = match("MKI67", names(seurat_g2m_genes))
+if (!is.na(idx)) {
+  mki67 = seurat_g2m_genes[[idx[1]]]
+} else {
+  mki67 = NULL
+  CalloutBox(x="Could not find 'PCNA' or its orthologue in the data!", type="warning")
+}
+
+seurat_s_genes = ScLists(sc, lists_slot="gene_lists", list="CC_S_phase")
+idx = match("PCNA", names(seurat_s_genes))
+if (!is.na(idx)) {
+  pcna = seurat_s_genes[[idx[1]]]
+} else {
+  pcna = NULL
+  CalloutBox(x="Could not find 'MKI67' or its orthologue in the data!", type="warning")
+}
+cell_cycle_markers = c(mki67, pcna)
 ```
 
 ```{r}
@@ -284,28 +308,40 @@ p
 
 ```{r}
 #| label: clusterqc_cellcycle_umap
-#| eval: !expr have_cellcyle_scores
-#| include: !expr have_cellcyle_scores
+#| eval: !expr have_cellcyle_scores | length(cell_cycle_markers) > 0
+#| include: !expr have_cellcyle_scores | length(cell_cycle_markers) > 0
 #| results: asis
 
-# Phases on UMAP
 plist = list()
-plist[["Phase"]] = Seurat::DimPlot(sc, group.by="Phase", pt.size=1, cols=ScColours(sc, "Phase")) + 
-  AddPlotStyle(title="", xlab="", ylab="")
 
-# Hack to colour by phase but label by
-barcodes = rownames(plist[["Phase"]]$data)
-plist[["Phase"]]$data$ident = sc[["seurat_clusters"]][barcodes,]
-plist[["Phase"]] = LabelClusters(plist[["Phase"]], id="ident", box=TRUE, fill="white", colour="black", label.padding=unit(0.05, "lines"))
-
-
-for (i in c("S.Score", "G2M.Score", "CC.Difference")) {
-  plist[[i]] = FeaturePlot(sc, features=i, pt.size=1, order=TRUE) +
-    AddPlotStyle(title="") + 
-    viridis::scale_color_viridis()
-  plist[[i]] = LabelClusters(plist[[i]], id="ident", box=TRUE, fill="white", colour="black", label.padding=unit(0.05, "lines"))
+if (have_cellcyle_scores) {
+    # Phases on UMAP
+    plist[["Phase"]] = Seurat::DimPlot(sc, group.by="Phase", pt.size=1, cols=ScColours(sc, "Phase")) + 
+      AddPlotStyle(title="", xlab="", ylab="")
+    
+    # Hack to colour by phase but label by
+    barcodes = rownames(plist[["Phase"]]$data)
+    plist[["Phase"]]$data$ident = sc[["seurat_clusters"]][barcodes,]
+    plist[["Phase"]] = LabelClusters(plist[["Phase"]], id="ident", box=TRUE, fill="white", colour="black", label.padding=unit(0.05, "lines"))
+    
+    
+    for (i in c("S.Score", "G2M.Score", "CC.Difference")) {
+      plist[[i]] = FeaturePlot(sc, features=i, pt.size=1, order=TRUE) +
+        AddPlotStyle(title="") + 
+        viridis::scale_color_viridis()
+      plist[[i]] = LabelClusters(plist[[i]], id="ident", box=TRUE, fill="white", colour="black", label.padding=unit(0.05, "lines"))
+    }
 }
 
+if (length(cell_cycle_markers) > 0) {
+    for (i in cell_cycle_markers) {
+      plist[[i]] = FeaturePlot(sc, features=i, pt.size=1, order=TRUE) +
+        AddPlotStyle(title="") + 
+        viridis::scale_color_viridis()
+      plist[[i]] = LabelClusters(plist[[i]], id="ident", box=TRUE, fill="white", colour="black", label.padding=unit(0.05, "lines"))
+    }
+}
+    
 captions = paste("UMAP coloured by", names(plist))
 names(captions) = names(plist)
 
@@ -336,11 +372,6 @@ for (i in names(plist)) {
 cat(":::", sep="\n")
 ```
 
-Alternatively, the expression of Ki67 and PCNA, if available, can be used to identify proliferating cells.
-
-```{r}
-
-```
 
 ## Software
 

--- a/modules/7_cluster_annotation/cluster_annotation.qmd
+++ b/modules/7_cluster_annotation/cluster_annotation.qmd
@@ -167,10 +167,6 @@ In addition to detecting marker genes, it might be informative to detect genes t
 # Find DEGs for every cluster compared to all remaining cells 
 # Report up-regulated DEGS (=markers NAMING CONVENTION) and down-regulated ones
 
-# Prepare SCT for marker detection
-if (grepl(pattern="_SCT$", x=default_assay, perl=TRUE)) sc = Seurat::PrepSCTFindMarkers(object=sc, assay=default_assay)
-
-
 # Latest best-practice paper recommends to use a Wilcox test
 # RunPresto is a wrapper around "immunogenomics/presto", which is a fast implementation of a Wilcox test
 markers = SeuratWrappers::RunPrestoAll(object=sc,


### PR DESCRIPTION
As discussed this pull request will do the following:

- PrepSCTFindMarkers will now be run at the end of the module dimensionality_reduction (Closes #37)
- Plots for cell cycle marker PCNA and MKI67 are shown for cluster qc

Other changes are:

- Fixed a small bug for setting up python path
- Fixed some settings in the _quarto-scrnaseq.yml